### PR TITLE
Fixed gradle dependency

### DIFF
--- a/OpenStreetMapViewer/build.gradle
+++ b/OpenStreetMapViewer/build.gradle
@@ -30,7 +30,7 @@ android {
 
 
 dependencies {
-    compile 'android.support:compatibility-v4:23+'
+    compile 'com.android.support:support-v4:23+'
     compile project(':osmdroid-android')
     //compile 'org.osmdroid:osmdroid-third-party:5.0-SNAPSHOT'
 }


### PR DESCRIPTION
Current project features a build error as it is unable to resolve **support:compatibility** in the **OpenStreetMapViewer\build.gradle**. This error is referenced in issue #194.

> Error:(32, 13) Failed to resolve: android.support:compatibility-v4:23+

This is resolved by replacing the dependency:

> compile 'android.support:compatibility-v4:23+'
> with
> compile 'com.android.support:support-v4:23+'
